### PR TITLE
Implement assigning judges to tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # giudice
 Avoid the traffic jam that is judging through automation!
+
+Note for future contributors/users, here is how we expect judging to work:
+* Judges go to their assigned tables and give each project TWO scores:
+  1. How well the project performs in its given track
+  2. How well the project performs overall (this is used to calculate overall winners)
+
+In the case of a project with no given track, it will be judged solely overall.

--- a/readtable.js
+++ b/readtable.js
@@ -1,31 +1,32 @@
-const csvFilePath='./submissions.csv'
-const csv=require('csvtojson')
+const csvFilePath='./submissions.csv';
+const csv=require('csvtojson');
 
+const TOTAL_JUDGING_TIME = 90; // How many minutes long is our judging period?
+const TIME_PER_PROJ = 9; // How many minutes should a judge spend judging a project?
+const VIEWS_PER_PROJ = 3; // How many judges should view a project?
 
+const PROJS_PER_JUDGE = TOTAL_JUDGING_TIME / TIME_PER_PROJ;
 
 function assignTables(projectsJson) {
-
 	let tableAssignmentIterator = 1;
 
-    for (var i in projectsJson) { // Iterate through all projects and assign tables
-    	var project = projectsJson[i]
-    	project.table = tableAssignmentIterator;
+  for (var i in projectsJson) { // Iterate through all projects and assign tables
+    var project = projectsJson[i]
+    project.table = tableAssignmentIterator;
 		tableAssignmentIterator++;
-    }
-
-    //console.log(projectsJson);
+  }
 }
 
 
 
 function getListOfTracks(projectsJson) {
   trackMap = {} // K-V: K=track, V=array of judging tables in that track
-  trackMap['General Prize'] = [] // This will contain every table (every project is considered for general prize)
+  //trackMap['General Prize'] = [] // This will contain every table (every project is considered for general prize)
 
   for (var project of projectsJson) { // Same as for..each but javascript
     tracks = project['Desired Prizes'].split(', '); // Make array of strings of prizes per team
     for (let i=0; i<tracks.length; i++) {
-      if (!(tracks[i] in trackMap)) { // if track already exists in dictionary
+      if (!(tracks[i] in trackMap)) { // if track doesn't already exist in dictionary
         trackMap[tracks[i]] = [];
         //console.log(trackMap);
       }
@@ -33,16 +34,73 @@ function getListOfTracks(projectsJson) {
       trackMap[tracks[i]].push(project['table']); // Appends table to list of tables signed up for that track
     }
 
-    trackMap['General Prize'].push(project['table']); // Append table to list of tables signed up for general prize
+    //trackMap['General Prize'].push(project['table']); // Append table to list of tables signed up for general prize
   }
   //console.log(trackMap);
 
   return trackMap;
 }
 
+
+
+let judges = ["Warren", "Sarah", "Zuul", "Bandalf", "Mari", "Pikachu", "Eevee", "Rattata", "Spearow", "Pidgey", "Professor Oak", "Professor Wayne Snyder", "Caterpie", "Charizard", "Growlithe"];
+
+
+function giveProjectsToJudges(trackMap, judges) {
+  judgeMap = {};
+  for (var judge of judges) {
+    judgeMap[judge] = {};
+  }
+
+  // VIEWS_PER_PROJ we use this
+  let judgeIndex = 0;
+  let numTablesAssignedToCurrentJudge = 0;
+
+
+  for (var track of Object.keys(trackMap)) {
+    console.log(track);
+    console.log(trackMap[track]);
+    for (var table of Object.values(trackMap[track])) {
+      console.log(table);
+      for (var i=judgeIndex; i<judgeIndex+VIEWS_PER_PROJ; i++) {
+        if (!(track in judgeMap[judges[i]])) {
+          judgeMap[judges[i]][track] = [];
+        }
+
+        console.log(judgeMap[judges[i]][track]);
+
+        judgeMap[judges[i]][track].push(table);
+      }
+      numTablesAssignedToCurrentJudge++;
+      if (numTablesAssignedToCurrentJudge >= PROJS_PER_JUDGE) {
+        judgeIndex += VIEWS_PER_PROJ;
+        numTablesAssignedToCurrentJudge = 0;
+      }
+    }
+  }
+
+  console.log(judgeMap);
+  // We give X judges the same schedule where X = # views per project
+  //for (var [track, tables] of Object.entries(trackMap)) {
+    //if (numTablesAssignedToCurrentJudge < VIEWS_PER_PROJ) {
+
+   // }
+  //}
+}
+
+
+
+
+
+function findNumberOfJudges(numProjects){
+  return (numProjects * VIEWS_PER_PROJ)/(TOTAL_JUDGING_TIME / TIME_PER_PROJ);
+}
+
+
 csv()
 .fromFile(csvFilePath)
 .then((jsonObj) => {
   assignTables(jsonObj);
-  getListOfTracks(jsonObj);
+  let trackMap = getListOfTracks(jsonObj);
+  giveProjectsToJudges(trackMap, judges);
 })

--- a/readtable.js
+++ b/readtable.js
@@ -8,6 +8,7 @@ const VIEWS_PER_PROJ = 3; // How many judges should view a project?
 const PROJS_PER_JUDGE = TOTAL_JUDGING_TIME / TIME_PER_PROJ;
 
 function assignTables(projectsJson) {
+  // returns number of tables
 	let tableAssignmentIterator = 1;
 
   for (var i in projectsJson) { // Iterate through all projects and assign tables
@@ -15,6 +16,8 @@ function assignTables(projectsJson) {
     project.table = tableAssignmentIterator;
 		tableAssignmentIterator++;
   }
+
+  return tableAssignmentIterator - 1; // Minus 1 because it will be 1 too big when exiting the loop
 }
 
 
@@ -43,7 +46,7 @@ function getListOfTracks(projectsJson) {
 
 
 
-let judges = ["Warren", "Sarah", "Zuul", "Bandalf", "Mari", "Pikachu", "Eevee", "Rattata", "Spearow", "Pidgey", "Professor Oak", "Professor Wayne Snyder", "Caterpie", "Charizard", "Growlithe"];
+let judges = ["Warren", "Sarah", "Zuul", "Bandalf", "Mari", "Pikachu", "Eevee", "Rattata", "Spearow", "Pidgey", "Professor Oak", "Professor Wayne Snyder", "Caterpie", "Charizard", "Growlithe", "Judge 16", "Judge Dredd", "Hardcodo the Great", "That One Guy", "Dad", "Mom", "Your long lost brother", "Nemo", "Julius Caesar", "Brutus", "Romeo", "Juliet", "The Witch", "The Girl with the Dragon Tattoo", "Spiderman", "Thanos the Mad Titan", "Judge 33", "Dr. Strange", "Iron Man", "Black Widow", "Vision", "Bruce Banner"]; //37 judges lol hardcoding
 
 
 function giveProjectsToJudges(trackMap, judges) {
@@ -58,11 +61,18 @@ function giveProjectsToJudges(trackMap, judges) {
 
 
   for (var track of Object.keys(trackMap)) {
-    console.log(track);
-    console.log(trackMap[track]);
+    console.log("PRINTING TRACKMAP:");
+    console.log(trackMap);
+    //console.log(track);
+    //console.log(trackMap[track]);
     for (var table of Object.values(trackMap[track])) {
+      //console.log("PRINTING TABLE:");
       console.log(table);
       for (var i=judgeIndex; i<judgeIndex+VIEWS_PER_PROJ; i++) {
+        console.log("Judge we are trying to look at:");
+        console.log(judges[i]);
+        console.log("PRINTING JUDGEMAP:");
+        console.log(judgeMap);
         if (!(track in judgeMap[judges[i]])) {
           judgeMap[judges[i]][track] = [];
         }
@@ -89,18 +99,61 @@ function giveProjectsToJudges(trackMap, judges) {
 }
 
 
+function findNumJudgements(trackMap) {
+  // This is different than simply the # of projects and is needed to
+  // calculate the number of judges we need.
+  // Ex: At BostonHacks Fall 2017, we had 50 projects, but since many
+  // projects needed to be judged on multiple tracks, there were 121
+  // judgements needed to be made. We needed 37 judges but if we had used
+  // 50 for our calculations, we would have calculated needing 15 judges.
+
+  //const reducer = (accumulator, currentProject) => accumulator + asdf;
+  let total = 0;
+
+  for (var tableArr of Object.values(trackMap)) {
+    total += tableArr.length;
+  }
+
+  return total;
+}
 
 
-
-function findNumberOfJudges(numProjects){
-  return (numProjects * VIEWS_PER_PROJ)/(TOTAL_JUDGING_TIME / TIME_PER_PROJ);
+function findNumberOfJudges(numJudgements){
+  return (numJudgements * VIEWS_PER_PROJ)/(TOTAL_JUDGING_TIME / TIME_PER_PROJ);
 }
 
 
 csv()
 .fromFile(csvFilePath)
 .then((jsonObj) => {
-  assignTables(jsonObj);
+  console.log("BostonHacks Giudice!");
+  console.log("====================\n");
+
+  console.log("Running the numbers:");
+  process.stdout.write("* Assigning table #s to projects...");
+  let numTables = assignTables(jsonObj);
+  console.log("done.");
+
+  process.stdout.write("* Mapping prize tracks to table #s...");
   let trackMap = getListOfTracks(jsonObj);
-  giveProjectsToJudges(trackMap, judges);
+  console.log("done.\n");
+
+  let numJudgements = findNumJudgements(trackMap);
+  let numJudges = findNumberOfJudges(numJudgements) + 2; // +2 is needed in case of edge case track and we have a judge judging only 1 project, TODO fix this
+  numJudges = Math.ceil(numJudges); // round up
+
+  console.log("Before we get started, here are your hackathon stats:");
+  console.log("* There are %d projects total.", numTables);
+  console.log("* There are effectively %d projects that need judging as some projects are registered for multiple tracks.\n", numJudgements);
+
+  console.log("Judging assumptions (YOU CAN CHANGE THESE VALUES):");
+  console.log("  * The judging period is %d minutes long.", TOTAL_JUDGING_TIME);
+  console.log("  * Each project must be seen by %d judges per track (excluding the overall track, except for teams that only submitted to that track).", VIEWS_PER_PROJ);
+  console.log("  * Each judge spends %d minutes at each table.\n", TIME_PER_PROJ);
+
+  console.log("Given these judging assumptions, we calculate that we need %d judges.", numJudges);
+
+  // TODO: Get judges from json file
+
+  //giveProjectsToJudges(trackMap, judges);
 })

--- a/readtable.js
+++ b/readtable.js
@@ -1,17 +1,48 @@
 const csvFilePath='./submissions.csv'
 const csv=require('csvtojson')
-csv()
-.fromFile(csvFilePath)
-.then((jsonObj) => {
-	let tableAssignmentIterator = 0;
 
-    for (var i in jsonObj) { // Iterate through all projects and assign table
-    	var project = jsonObj[i]
+
+
+function assignTables(projectsJson) {
+
+	let tableAssignmentIterator = 1;
+
+    for (var i in projectsJson) { // Iterate through all projects and assign tables
+    	var project = projectsJson[i]
     	project.table = tableAssignmentIterator;
 		tableAssignmentIterator++;
     }
 
-    console.log(jsonObj);
-}).then(() => {
-	const jsonArray = csv().fromFile(csvFilePath);
+    //console.log(projectsJson);
+}
+
+
+
+function getListOfTracks(projectsJson) {
+  trackMap = {} // K-V: K=track, V=array of judging tables in that track
+  trackMap['General Prize'] = [] // This will contain every table (every project is considered for general prize)
+
+  for (var project of projectsJson) { // Same as for..each but javascript
+    tracks = project['Desired Prizes'].split(', '); // Make array of strings of prizes per team
+    for (let i=0; i<tracks.length; i++) {
+      if (!(tracks[i] in trackMap)) { // if track already exists in dictionary
+        trackMap[tracks[i]] = [];
+        //console.log(trackMap);
+      }
+
+      trackMap[tracks[i]].push(project['table']); // Appends table to list of tables signed up for that track
+    }
+
+    trackMap['General Prize'].push(project['table']); // Append table to list of tables signed up for general prize
+  }
+  //console.log(trackMap);
+
+  return trackMap;
+}
+
+csv()
+.fromFile(csvFilePath)
+.then((jsonObj) => {
+  assignTables(jsonObj);
+  getListOfTracks(jsonObj);
 })


### PR DESCRIPTION
Implements the algorithm we came up with at hacktoberfest, (PVt/T) / (T/t) = # of judges

Doing `node readtable.js` now prints out a detailed log of what giudice's doing. It now generates JSON that pairs judges to tracks and tables per track! Which looks like this:

```
{ Warren:
   { 'Amazon Web Services - Best Use of AWS': [ 1, 9, 32 ],
     'Twilio — Best use of Twilio API': [ 1, 7, 9, 15, 18, 21, 22 ] },
  Sarah:
   { 'Amazon Web Services - Best Use of AWS': [ 1, 9, 32 ],
     'Twilio — Best use of Twilio API': [ 1, 7, 9, 15, 18, 21, 22 ] },
  Zuul:
   { 'Amazon Web Services - Best Use of AWS': [ 1, 9, 32 ],
     'Twilio — Best use of Twilio API': [ 1, 7, 9, 15, 18, 21, 22 ] },
...
}
```

Future todos:
* Make a front end so this is more human readable
* Get judges from an external source instead of a hardcoded array
* Allow us to ignore certain sponsor tracks in judge assignment, because we won't be judging those (sponsors will send judges to judge their tracks). 
* Fix findNumberOfJudges so that it doesn't underestimate the number of judges we need (right now we manually increase # of calculated judges by 2)